### PR TITLE
GraphQL body type support

### DIFF
--- a/convertJsonFile.js
+++ b/convertJsonFile.js
@@ -4,7 +4,7 @@
 * multiple workspaces; environments; cookies
 * keep order
 * 'Docs' export
-* unhandled types of request data (yaml, edn and graph query)
+* unhandled types of request data (yaml and edn query)
 * add a dummy req containing info and directions wrt the generator script, env. aspect etc.
 * remove extra maps[1]; try removing intermediate folders
 
@@ -110,6 +110,14 @@ function transformBody(insomniaBody) {
             body.file = {};
             body.file.src = "/C:/PleaseSelectAFile";
             console.warn("Warning: A file is supposed to be a part of the request!!! Would need to be manually selected in Postman.");
+            break;
+        case "application/graphql":
+            var graphqlBody = JSON.parse(insomniaBody.text);
+
+            body.mode = "graphql";
+            body.graphql = {};
+            body.graphql.query = graphqlBody.query;
+            body.graphql.variables = JSON.stringify(graphqlBody.variables)
             break;
         default:
             console.warn("Warning: Body type unsupported; skipped!!! ... " + insomniaBody.mimeType);


### PR DESCRIPTION
Added support for GraphQL body type. An example of an Insomnia export file with GraphQL queries can be found here https://gist.github.com/SSergey-Kolesnikov/2398f4cb9d688bd9f6c37c9d13481dc4. This is how the request looks in Insomnia  http://joxi.ru/8Anow7dIzJJx0r, and so in Postman http://joxi.ru/L21zaZQSRMMqLA after import.